### PR TITLE
fix[pre-commit]: pin hooks to v5.0.0 for py38

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
We updated `.pre-commit-config.yaml` by changing the `pre-commit-hooks` revision from `v4.6.0` to `v5.0.0`, which removes the deprecated stage-name warnings while still keeping compatibility with Python 3.8. This was the only change included in the PR.