### PR TITLE
fix: remove duplicate test function

### DIFF
--- a/tests/testmanager.py
+++ b/tests/testmanager.py
@@ -170,12 +170,6 @@ def test_setup_hooks():
         )
 
 
-def test_cli_main_basic():
-    # Test basic CLI output via subprocess (already exists, but ensure it works)
-    # The existing test_cli_output covers this
-    pass
-
-
 def test_cli_with_system_message():
     result = subprocess.run(
         [

--- a/tests/testmanager.py
+++ b/tests/testmanager.py
@@ -176,20 +176,6 @@ def test_cli_main_basic():
     pass
 
 
-def test_cli_missing_message_error():
-    # Test CLI with missing message
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "from manager.cli import main; import sys; sys.argv = ['cli', '--tools', 'web_search']; main()",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode != 0  # Should fail due to missing --message
-
-
 def test_cli_with_system_message():
     result = subprocess.run(
         [


### PR DESCRIPTION
## Summary
- Remove duplicate test function `test_cli_missing_message_error` from the test suite to eliminate redundancy.
- Remove redundant empty test function `test_cli_main_basic` as it was covered by existing tests.

These changes improve the maintainability and clarity of the test suite.

The removed code blocks were:

**Duplicate function:**
```python
def test_cli_missing_message_error():
    # Test CLI with missing message
    result = subprocess.run(
        [
            sys.executable,
            "-c",
            "from manager.cli import main; import sys; sys.argv = ['cli', '--tools', 'web_search']; main()",
        ],
        capture_output=True,
        text=True,
    )
    assert result.returncode != 0  # Should fail due to missing --message
```

**Redundant function:**
```python
def test_cli_main_basic():
    # Test basic CLI output via subprocess (already exists, but ensure it works)
    # The existing test_cli_output covers this
    pass
```

Removing these improves the test suite's clarity and reduces maintenance overhead.