### PR TITLE
fix: use local path for cla document

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path-to-document: "https://github.com/bniladridas/manager/blob/main/CLA.md"
+          path-to-document: "CLA.md"
           branch: cla-signatures
           path-to-signatures: "signatures/cla.json"
           use-dco-flag: false


### PR DESCRIPTION
Changes the CLA document path from URL to local file to fix the JavaScript error in the CLA action.