### PR TITLE
fix: add remote repo name to cla action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -43,6 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-document: "CLA.md"
+          remote-repository-name: bniladridas/manager
           branch: cla-signatures
           path-to-signatures: "signatures/cla.json"
           use-dco-flag: false


### PR DESCRIPTION
Adds remote-repository-name input to the CLA action to fix the JavaScript error and ensure proper operation.