### PR TITLE
docs: update CLA comment template for manual signing

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,12 +33,22 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: ".github/cla/comment-template.md"
 
-       - name: Post CLA Manual Signing Instructions
-         if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
-         uses: peter-evans/create-or-update-comment@v4
-         with:
-           issue-number: ${{ github.event.pull_request.number }}
-           body-path: ".github/cla/comment-template.md"
+      - name: Run CLA Assistant
+        if: >
+          github.event_name == 'pull_request_target' ||
+          contains(github.event.comment.body, 'recheck') ||
+          contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')
+        uses: contributor-assistant/github-action@v2.6.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: "CLA.md"
+          remote-repository-name: bniladridas/manager
+          branch: cla-signatures
+          path-to-signatures: "signatures/cla.json"
+          use-dco-flag: false
+          allowlist: ""
+          lock-pullrequest-aftermerge: true
 
       - name: Split signatures into per-user files
         run: |


### PR DESCRIPTION
Updates the CLA comment template to reflect the manual signing process since the CLA action is disabled due to a persistent bug.