### PR TITLE
feat: restore CLA bot for PR locking

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,60 +33,60 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: ".github/cla/comment-template.md"
 
-       # - name: Run CLA Assistant
-       #   if: >
-       #     github.event_name == 'pull_request_target' ||
-       #     contains(github.event.comment.body, 'recheck') ||
-       #     contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')
-       #   uses: contributor-assistant/github-action@v2.6.1
-       #   env:
-       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       #   with:
-       #     path-to-document: "CLA.md"
-       #     remote-repository-name: bniladridas/manager
-       #     branch: cla-signatures
-       #     path-to-signatures: "signatures/cla.json"
-       #     use-dco-flag: false
-       #     allowlist: ""
-       #     lock-pullrequest-aftermerge: true
+      - name: Run CLA Assistant
+        if: >
+          github.event_name == 'pull_request_target' ||
+          contains(github.event.comment.body, 'recheck') ||
+          contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')
+        uses: contributor-assistant/github-action@v2.6.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: "CLA.md"
+          remote-repository-name: bniladridas/manager
+          branch: cla-signatures
+          path-to-signatures: "signatures/cla.json"
+          use-dco-flag: false
+          allowlist: ""
+          lock-pullrequest-aftermerge: true
 
-       # - name: Split signatures into per-user files
-       #   run: |
-       #     mkdir -p signatures/users
+      - name: Split signatures into per-user files
+        run: |
+          mkdir -p signatures/users
 
-       #     jq -r 'keys[]' signatures/cla.json | while read user; do
-       #       jq ".\"$user\"" signatures/cla.json > signatures/users/"$user".json
-       #     done
+          jq -r 'keys[]' signatures/cla.json | while read user; do
+            jq ".\"$user\"" signatures/cla.json > signatures/users/"$user".json
+          done
 
-       # - name: Commit signature updates
-       #   run: |
-       #     if [ -n "$(git status --porcelain signatures)" ]; then
-       #       git config user.name "cla-bot"
-       #       git config user.email "cla-bot@users.noreply.github.com"
-       #       git add signatures
-       #       git commit -m "chore(cla): update CLA signatures [skip ci]"
-       #       git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-       #     else
-       #       echo "No signature updates."
-       #     fi
+      - name: Commit signature updates
+        run: |
+          if [ -n "$(git status --porcelain signatures)" ]; then
+            git config user.name "cla-bot"
+            git config user.email "cla-bot@users.noreply.github.com"
+            git add signatures
+            git commit -m "chore(cla): update CLA signatures [skip ci]"
+            git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          else
+            echo "No signature updates."
+          fi
 
-       # - name: Regenerate SIGNERS.md
-       #   run: |
-       #     echo "# Contributors Who Signed the CLA" > SIGNERS.md
-       #     echo "" >> SIGNERS.md
-       #     for file in signatures/users/*.json; do
-       #       user=$(basename "$file" .json)
-       #       echo "- @$user" >> SIGNERS.md
-       #     done
-       #     git add SIGNERS.md
-       #     git commit -m "docs(cla): update SIGNERS.md [skip ci]" || true
-       #     git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" || true
+      - name: Regenerate SIGNERS.md
+        run: |
+          echo "# Contributors Who Signed the CLA" > SIGNERS.md
+          echo "" >> SIGNERS.md
+          for file in signatures/users/*.json; do
+            user=$(basename "$file" .json)
+            echo "- @$user" >> SIGNERS.md
+          done
+          git add SIGNERS.md
+          git commit -m "docs(cla): update SIGNERS.md [skip ci]" || true
+          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" || true
 
-       # - name: Update PR Status Check
-       #   uses: LouisBrunner/checks-action@v2
-       #   with:
-       #     token: ${{ secrets.GITHUB_TOKEN }}
-       #     sha: ${{ github.event.pull_request.head.sha }}
-       #     name: "CLA Check"
-       #     conclusion: success
-       #     status: completed
+      - name: Update PR Status Check
+        uses: LouisBrunner/checks-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          name: "CLA Check"
+          conclusion: success
+          status: completed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+        args: [--target-version, py38]
       - id: ruff
         name: ruff-check
         args: [--no-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,8 @@ requires-python = ">=3.8"
  python_functions = ["test_*"]
  addopts = "--cov=manager --cov-report=term-missing"
 
- [tool.setuptools.packages.find]
- exclude = ["signatures"]
+  [tool.setuptools.packages.find]
+  exclude = ["signatures"]
+
+[tool.ruff]
+target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,6 @@ requires-python = ">=3.8"
 
 [tool.ruff]
 target-version = "py38"
+
+[tool.ruff.lint]
+extend-ignore = ["UP041"]

--- a/tests/testmanager.py
+++ b/tests/testmanager.py
@@ -149,12 +149,11 @@ def test_edge_cases():
 def test_setup_hooks():
     from manager.cli import setup_hooks
 
-    with (
-        patch("pathlib.Path.exists") as mock_exists,
-        patch("shutil.copy") as mock_copy,
-        patch("os.chmod") as mock_chmod,
-        patch("builtins.print") as mock_print,
-    ):
+    with patch("pathlib.Path.exists") as mock_exists, patch(
+        "shutil.copy"
+    ) as mock_copy, patch("os.chmod") as mock_chmod, patch(
+        "builtins.print"
+    ) as mock_print:
         # Test when .git/hooks exists and script exists
         mock_exists.return_value = True
         setup_hooks()


### PR DESCRIPTION
## Summary
- Re-enable CLA Assistant workflow to enforce contributor license agreement signing on pull requests
- Configure PR locking after merge to prevent further changes
- Update ruff target version to Python 3.8 for compatibility
- Adjust pre-commit hooks accordingly
- Fix test syntax for older Python versions

This restores automated CLA management that was previously disabled in favor of manual signing.