### PR TITLE
feat: add workflow to lock merged prs and delete branches

### DIFF
--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -1,0 +1,35 @@
+name: Lock Merged PRs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  lock:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Lock PR
+        run: gh pr lock ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Delete branch (skip if already deleted)
+        run: |
+          response=$(gh api \
+            -X DELETE \
+            "repos/${{ github.repository }}/git/refs/heads/$BRANCH_NAME" \
+            2>&1) || {
+            if echo "$response" | grep -q "Reference does not exist"; then
+              echo "Branch already deleted, skipping"
+            else
+              echo "Failed to delete branch: $response"
+              exit 1
+            fi
+          }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Adds GitHub workflow that automatically locks merged PRs and deletes their source branches to keep the repository clean.