### PR TITLE
Fix/yamllint issues

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 ---
 name: 'Test'
 description: 'Run tests for the project'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,3 +1,4 @@
+---
 name: 'Test'
 description: 'Run tests for the project'
 inputs:

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
 name: 'Test'
 description: 'Run tests for the project'

--- a/.github/workflows/cla-status.yml
+++ b/.github/workflows/cla-status.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 ---
 name: CLA Status Badge
 

--- a/.github/workflows/cla-status.yml
+++ b/.github/workflows/cla-status.yml
@@ -1,3 +1,4 @@
+---
 name: CLA Status Badge
 
 on:

--- a/.github/workflows/cla-status.yml
+++ b/.github/workflows/cla-status.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
 name: CLA Status Badge
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -38,7 +38,7 @@ jobs:
           github.event_name == 'pull_request_target' ||
           contains(github.event.comment.body, 'recheck') ||
           contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')
-        uses: contributor-assistant/github-action@v2.7.0
+        uses: contributor-assistant/github-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -60,18 +60,24 @@ jobs:
           done
 
       - name: Commit signature updates
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           if [ -n "$(git status --porcelain signatures)" ]; then
             git config user.name "cla-bot"
             git config user.email "cla-bot@users.noreply.github.com"
             git add signatures
             git commit -m "chore(cla): update CLA signatures [skip ci]"
-            git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+            git push "https://x-access-token:$GITHUB_TOKEN@github.com/$REPO.git"
           else
             echo "No signature updates."
           fi
 
       - name: Regenerate SIGNERS.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           echo "# Contributors Who Signed the CLA" > SIGNERS.md
           echo "" >> SIGNERS.md
@@ -81,7 +87,7 @@ jobs:
           done
           git add SIGNERS.md
           git commit -m "docs(cla): update SIGNERS.md [skip ci]" || true
-          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" || true
+          git push "https://x-access-token:$GITHUB_TOKEN@github.com/$REPO.git" || true
 
       - name: Update PR Status Check
         uses: LouisBrunner/checks-action@v2

--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -1,3 +1,4 @@
+---
 name: Lock Merged PRs
 
 on:

--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
 name: Lock Merged PRs
 

--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 ---
 name: Lock Merged PRs
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 manager
+Copyright (c) 2026 manager
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
> We cleaned up the YAML files:

- Fixed yamllint complaints about missing --- at the top of files
- Shortened some super long lines that were breaking the 110 character limit
- Added proper MIT license headers 
- Bumped the copyright year to 2026
- Fixed a broken GitHub Action that was trying to use a version that doesn't exist

Basically just housekeeping stuff to make the linter happy and keep things tidy.