### PR TITLE
docs: fix readme code snippet documentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
- manager/__init__.py:46
+ manager/__init__.py:133
 
 ```python
 def render_chat_with_tools(
     self,
     model: str,
     messages: List[Dict[str, str]],
-    tools: List[Dict[str, str]],
-    template_name: str = "chatwithtools.jinja",
+    tools: List[Dict[str, Any]],  # Fixed: was List[Dict[str, str]]
+    template_name: str = "chat_completions.jinja",  # Fixed: was "chatwithtools.jinja"
     **kwargs: Any
 ) -> str:
     """Render a JSON payload for xAI API chat completions with tools.


### PR DESCRIPTION
We are seeing documentation inconsistencies in the README code snippet for https://github.com/harpertoken/manager/blob/main/README.md, so this is a targeted fix for accuracy:

https://github.com/harpertoken/manager/blob/main/manager/__init__.py#L133

Note this corrects the line number reference (46 → 133), tools parameter type (List[Dict[str, str]] → List[Dict[str, Any]]), and template name (chatwithtools.jinja → chat_completions.jinja), which I believe were causing confusion for users trying to understand the deprecated method signature.