### PR TITLE
docs: replace readme snippet with actual implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- manager/__init__.py:133
+ manager/__init__.py:134
 
 ```python
 def render_chat_with_tools(
@@ -14,8 +14,6 @@ def render_chat_with_tools(
     DEPRECATED: The /v1/messages endpoint is deprecated.
     Use render_chat_completions() for /v1/chat/completions endpoint.
     """
-    import warnings
-
     warnings.warn(
         "render_chat_with_tools is deprecated. Use render_chat_completions() instead.",
         DeprecationWarning,

--- a/README.md
+++ b/README.md
@@ -5,27 +5,24 @@ def render_chat_with_tools(
     self,
     model: str,
     messages: List[Dict[str, str]],
-    tools: List[Dict[str, Any]],  # Fixed: was List[Dict[str, str]]
-    template_name: str = "chat_completions.jinja",  # Fixed: was "chatwithtools.jinja"
-    **kwargs: Any
+    tools: List[Dict[str, Any]],
+    template_name: str = "chat_completions.jinja",
+    **kwargs: Any,
 ) -> str:
-    """Render a JSON payload for xAI API chat completions with tools.
+    """Legacy method - use render_chat_completions instead.
 
-    Args:
-        model (str): The model name (e.g., "grok-beta").
-        messages (List[Dict[str, str]]): List of message dicts with 'role' and 'content'.
-        tools (List[Dict[str, str]]): List of tool dicts with 'type' and 'name'.
-        template_name (str): Name of the Jinja2 template to use.
-        **kwargs: Additional parameters to pass to the template (e.g., temperature, max_tokens).
-
-    Returns:
-        str: The rendered JSON payload.
-
-    Raises:
-        ValueError: If inputs do not meet validation requirements.
+    DEPRECATED: The /v1/messages endpoint is deprecated.
+    Use render_chat_completions() for /v1/chat/completions endpoint.
     """
+    import warnings
+
+    warnings.warn(
+        "render_chat_with_tools is deprecated. Use render_chat_completions() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     self._validate_messages(messages)
-    self._validate_tools(tools)
+    self._validate_tools_legacy(tools)
     if not isinstance(model, str):
         raise ValueError("Model must be a string")
     template = self.env.get_template(template_name)

--- a/manager/__init__.py
+++ b/manager/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
+import warnings
 from typing import Any, Dict, List
 
 from ._version import __version__
@@ -143,8 +144,6 @@ class Manager:
         DEPRECATED: The /v1/messages endpoint is deprecated.
         Use render_chat_completions() for /v1/chat/completions endpoint.
         """
-        import warnings
-
         warnings.warn(
             "render_chat_with_tools is deprecated. Use render_chat_completions() instead.",
             DeprecationWarning,


### PR DESCRIPTION
After merging PR #25 to fix basic README documentation errors, I discovered the snippet had deeper issues - it was showing an idealized version instead of the actual deprecated method implementation.

The README snippet at https://github.com/harpertoken/manager/blob/main/README.md was misleading users about what the deprecated method actually does:

https://github.com/harpertoken/manager/blob/main/manager/__init__.py#L134

This PR replaces the entire snippet with the real implementation, including:
- Actual deprecation warning (not idealized docstring)
- Correct validation method (_validate_tools_legacy vs _validate_tools)
- PEP 8 compliant import structure (warnings at module level)
- Fixed line number reference (134 not 133)

The old snippet made it look like a fully-featured method when it's actually a simple deprecated wrapper. This should give users accurate expectations about the method's behavior.